### PR TITLE
WR441709: Fix unit test failure

### DIFF
--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -38,7 +38,7 @@ require_once($CFG->dirroot . '/mod/simplecertificate/tests/base_test.php');
  */
 
 // ...vendor/bin/phpunit mod_simplecertificate_locallib_testcase mod/simplecertificate/tests/locallib_test.php .
-class mod_simplecertificate_locallib_testcase extends mod_simplecertificate_base_testcase {
+class mod_simplecertificate_locallib_test extends mod_simplecertificate_base_testcase {
 
     public function test_create_instance() {
         global $DB;
@@ -121,8 +121,8 @@ class mod_simplecertificate_locallib_testcase extends mod_simplecertificate_base
 
         // Test if can create certificate without any images.
         $cert = $this->create_instance(array('certificateimage' => '', 'secondimage' => ''));
-        $this->assertAttributeEmpty('certificateimage', $cert->get_instance());
-        $this->assertAttributeEmpty('secondimage', $cert->get_instance());
+        $this->assertEmpty($cert->get_instance()->certificateimage, 'certificateimage should be empty');
+        $this->assertEmpty($cert->get_instance()->secondimage, 'secondimage should be empty');
     }
 
     public function test_certificate_texts() {
@@ -134,8 +134,8 @@ class mod_simplecertificate_locallib_testcase extends mod_simplecertificate_base
         $secondpagetext = $cert->testable_get_certificate_text($cert->get_issue(), $cert->get_instance()->secondpagetext);
         // In this test first must be different than second one.
         $this->assertNotEquals($firstpagetext, $secondpagetext);
-        $this->assertNotContains("{", $firstpagetext);
-        $this->assertNotContains("{", $secondpagetext);
+        $this->assertStringNotContainsString("{", $firstpagetext, 'First page text should not contain unprocessed placeholders');
+        $this->assertStringNotContainsString("{", $secondpagetext, 'Second page text should not contain unprocessed placeholders');
     }
 
     public function test_create_issue_instance() {


### PR DESCRIPTION
```
2) mod_simplecertificate_locallib_testcase::test_certificate_images
Error: Call to undefined method mod_simplecertificate_locallib_testcase::assertAttributeEmpty()

/var/www/site/mod/simplecertificate/tests/locallib_test.php:124
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80

3) mod_simplecertificate_locallib_testcase::test_certificate_texts
TypeError: PHPUnit\Framework\Assert::assertNotContains(): Argument #2 ($haystack) must be of type iterable, string given, called in /var/www/site/mod/simplecertificate/tests/locallib_test.php on line 137

/var/www/site/mod/simplecertificate/tests/locallib_test.php:137
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
```