### PR TITLE
Unit test faling for mod_simplecertificate

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -27,7 +27,7 @@ use core_privacy\local\request\writer;
  * Class provider
  *
  * @package    mod_simplecertificate
- * @copyright  2024 YOUR NAME <your@email.com>
+ * @copyright  2024 Karl Michael Reyes <michaelreyes@catalyst-ca.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements 
@@ -117,7 +117,7 @@ class provider implements
 
     public static function export_user_preferences(int $userid) {
         // Fetch user preference for the simplecertificate plugin.
-        $certificateemailnotification = get_user_preference('certificateemailnotification', null, $userid);
+        $certificateemailnotification = get_user_preferences('certificateemailnotification', null, $userid);
 
         // Check if the preference is set and handle the description accordingly.
         if (null !== $certificateemailnotification) {

--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -84,7 +84,7 @@ class mod_simplecertificate_base_testcase extends advanced_testcase {
     /**
      * Setup function - we will create a course and add an simplecertificate instance to it.
      */
-    protected function setUp():void {
+    protected function setUp(): void {
         global $DB;
 
         $this->resetAfterTest(true);

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -121,8 +121,8 @@ class mod_simplecertificate_locallib_testcase extends mod_simplecertificate_base
 
         // Test if can create certificate without any images.
         $cert = $this->create_instance(array('certificateimage' => '', 'secondimage' => ''));
-        $this->assertAttributeEmpty('certificateimage', $cert->get_instance());
-        $this->assertAttributeEmpty('secondimage', $cert->get_instance());
+        $this->assertEmpty($cert->get_instance()->certificateimage, 'certificateimage should be empty');
+        $this->assertEmpty($cert->get_instance()->secondimage, 'secondimage should be empty');
     }
 
     public function test_certificate_texts() {
@@ -134,8 +134,8 @@ class mod_simplecertificate_locallib_testcase extends mod_simplecertificate_base
         $secondpagetext = $cert->testable_get_certificate_text($cert->get_issue(), $cert->get_instance()->secondpagetext);
         // In this test first must be different than second one.
         $this->assertNotEquals($firstpagetext, $secondpagetext);
-        $this->assertNotContains("{", $firstpagetext);
-        $this->assertNotContains("{", $secondpagetext);
+        $this->assertStringNotContainsString("{", $firstpagetext, 'First page text should not contain unprocessed placeholders');
+        $this->assertStringNotContainsString("{", $secondpagetext, 'Second page text should not contain unprocessed placeholders');
     }
 
     public function test_create_issue_instance() {


### PR DESCRIPTION
```
2) mod_simplecertificate_locallib_testcase::test_certificate_images
Error: Call to undefined method mod_simplecertificate_locallib_testcase::assertAttributeEmpty()

/var/www/site/mod/simplecertificate/tests/locallib_test.php:124
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80

3) mod_simplecertificate_locallib_testcase::test_certificate_texts
TypeError: PHPUnit\Framework\Assert::assertNotContains(): Argument #2 ($haystack) must be of type iterable, string given, called in /var/www/site/mod/simplecertificate/tests/locallib_test.php on line 137

/var/www/site/mod/simplecertificate/tests/locallib_test.php:137
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80

4) tool_dataprivacy\expired_data_requests_test::test_data_request_expiry
Unexpected debugging() call detected.
Debugging: Call to undefined function mod_simplecertificate\privacy\get_user_preference()
* line 8154 of /lib/moodlelib.php: call to mod_simplecertificate\privacy\provider::export_user_preferences()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 361 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 114 of /admin/tool/dataprivacy/classes/task/process_data_request_task.php: call to core_privacy\manager->export_user_data()
* line 742 of /lib/phpunit/classes/advanced_testcase.php: call to tool_dataprivacy\task\process_data_request_task->execute()
* line 72 of /admin/tool/dataprivacy/tests/expired_data_requests_test.php: call to advanced_testcase->runAdhocTasks()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_data_requests_test->test_data_request_expiry()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 80 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 653 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 98 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()


/var/www/site/lib/phpunit/classes/advanced_testcase.php:105

5) tool_dataprivacy\expired_data_requests_test::test_data_request_expiry_never
Unexpected debugging() call detected.
Debugging: Call to undefined function mod_simplecertificate\privacy\get_user_preference()
* line 8154 of /lib/moodlelib.php: call to mod_simplecertificate\privacy\provider::export_user_preferences()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 361 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 114 of /admin/tool/dataprivacy/classes/task/process_data_request_task.php: call to core_privacy\manager->export_user_data()
* line 742 of /lib/phpunit/classes/advanced_testcase.php: call to tool_dataprivacy\task\process_data_request_task->execute()
* line 136 of /admin/tool/dataprivacy/tests/expired_data_requests_test.php: call to advanced_testcase->runAdhocTasks()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_data_requests_test->test_data_request_expiry_never()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 80 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 653 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 98 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()


/var/www/site/lib/phpunit/classes/advanced_testcase.php:105

6) tool_dataprivacy\expired_data_requests_test::test_is_expired
Unexpected debugging() call detected.
Debugging: Call to undefined function mod_simplecertificate\privacy\get_user_preference()
* line 8154 of /lib/moodlelib.php: call to mod_simplecertificate\privacy\provider::export_user_preferences()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 361 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 114 of /admin/tool/dataprivacy/classes/task/process_data_request_task.php: call to core_privacy\manager->export_user_data()
* line 742 of /lib/phpunit/classes/advanced_testcase.php: call to tool_dataprivacy\task\process_data_request_task->execute()
* line 183 of /admin/tool/dataprivacy/tests/expired_data_requests_test.php: call to advanced_testcase->runAdhocTasks()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_data_requests_test->test_is_expired()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 80 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 653 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 98 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()
```